### PR TITLE
fix: flex overflow on mobile

### DIFF
--- a/src/lib/components/sections/Hero.svelte
+++ b/src/lib/components/sections/Hero.svelte
@@ -11,7 +11,7 @@
         forget.
       </p>
     </div>
-    <div class="flex flex-col sm:flex-row items-start sm:items-center gap-5 sm:gap-9">
+    <div class="flex flex-wrap items-center gap-5 sm:gap-9">
       <div class="bg-secondary">
         <a
           href="#downloads"

--- a/src/lib/components/sections/Hero.svelte
+++ b/src/lib/components/sections/Hero.svelte
@@ -11,7 +11,7 @@
         forget.
       </p>
     </div>
-    <div class="flex items-center gap-5 sm:gap-9">
+    <div class="flex flex-col sm:flex-row items-start sm:items-center gap-5 sm:gap-9">
       <div class="bg-secondary">
         <a
           href="#downloads"


### PR DESCRIPTION
On iPhone 12 mini
Before:
![image](https://github.com/user-attachments/assets/4b98d77e-f514-4861-8a7a-1de2f1decbfe)
After:
![image](https://github.com/user-attachments/assets/4aba90ba-edd9-4241-b497-5935ec40a3e8)
