### PR TITLE
Minor Wording Changes

### DIFF
--- a/src/lib/components/sections/Advantages.svelte
+++ b/src/lib/components/sections/Advantages.svelte
@@ -10,9 +10,9 @@
 
   const advantages: Advantage[] = [
     {
-      title: 'synchronisation',
+      title: 'synchronization',
       description:
-        'The free AnkiWeb synchronisation service lets you sync your cards across devices.',
+        'The free AnkiWeb synchronization service lets you sync your cards across devices.',
       icon: '/icons/synchronize.svg',
     },
     {
@@ -21,12 +21,12 @@
       icon: '/icons/gallery.svg',
     },
     {
-      title: 'customisation',
+      title: 'customization',
       description: 'Easily change your flashcard layouts and the timing of their reviews.',
       icon: '/icons/customisation.svg',
     },
     {
-      title: 'optimisation',
+      title: 'optimization',
       description: 'Anki can handle decks of 100,000+ cards with no problems.',
       icon: '/icons/optimisation.svg',
     },

--- a/src/lib/components/sections/Contributing.svelte
+++ b/src/lib/components/sections/Contributing.svelte
@@ -16,7 +16,7 @@
       href: 'https://github.com/ankitects/anki/blob/main/docs/contributing.md',
     },
     {
-      title: 'shared decks',
+      title: 'share decks',
       description:
         "Sharing your deck can make it easier for others to start learning what you're studying.",
       href: 'https://docs.ankiweb.net/contrib#sharing-decks-publicly',


### PR DESCRIPTION
"Shared Decks" should be in imperative like "Translate Anki" is.

And in places where we use *s* (synchronisation, optimisation) we should be using *z* instead.