### PR TITLE
feat: remove empty spaces from advantage cards

### DIFF
--- a/src/lib/components/common/AdvantageCard.svelte
+++ b/src/lib/components/common/AdvantageCard.svelte
@@ -11,7 +11,7 @@
 </script>
 
 <div
-  class="border-white/[13%] gap-2 flex flex-col justify-end xl:aspect-[16/10] xl:px-14 xl:py-9 xl:border-2"
+  class="border-white/[13%] gap-2 flex flex-col justify-end xl:px-14 xl:py-9 xl:border-2"
 >
   <div class="flex items-center gap-4 xl:items-start xl:flex-col xl:gap-3">
     <img src="{base}{icon}" alt="icon" class="size-8 xl:size-12" />


### PR DESCRIPTION
Original debate: https://forums.ankiweb.net/t/creation-of-new-landing-page/42555/21

It seems like both websites have removed that empty design.