### PR TITLE
fix: use grid-cols-3 on tablet screen size

### DIFF
--- a/src/lib/components/sections/Advantages.svelte
+++ b/src/lib/components/sections/Advantages.svelte
@@ -44,7 +44,7 @@
       <p>Here are a few reasons why users love Anki.</p>
     {/snippet}
   </DualHeader>
-  <div class="grid xl:grid-cols-6 gap-9">
+  <div class="grid lg:grid-cols-3 xl:grid-cols-6 gap-9">
     {#each advantages as { title, description, icon }, i}
       <div class={i > 1 ? 'xl:col-span-2' : 'xl:col-span-3'}>
         <AdvantageCard {title} {description} {icon} />


### PR DESCRIPTION
This change will optimize space usage.

Before:
![image](https://github.com/user-attachments/assets/0efb5696-0613-41a7-bca1-c124e8c8e01b)
After:
![image](https://github.com/user-attachments/assets/265f5c11-3e15-473a-8b64-77cbeb998053)
