### PR TITLE
feat: add color to titles

### DIFF
--- a/src/lib/components/common/DualHeader.svelte
+++ b/src/lib/components/common/DualHeader.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <hgroup class="flex flex-col gap-3">
-  <h2 {id} class="text-2xl xl:text-4xl tracking-[1.65px] uppercase font-medium scroll-mt-32">
+  <h2 {id} class="text-2xl xl:text-4xl tracking-[1.65px] uppercase font-medium scroll-mt-32 text-transparent bg-linear-10 bg-clip-text from-primary-darker to-primary">
     {title}
   </h2>
   <div class="text-lg xl:text-3xl xl:tracking-[1.02px] xl:leading-[45px] text-neutral">


### PR DESCRIPTION
As the old site used blue color for the title of each section, I have incorporated it here. This helps mitigate the [washed-out](https://github.com/ankitects/anki-landing-page/pull/23#issuecomment-2661505588) problem.