### PR TITLE
Detect platform

### DIFF
--- a/src/lib/components/sections/Downloads.svelte
+++ b/src/lib/components/sections/Downloads.svelte
@@ -175,6 +175,7 @@
           >
             {@render detected[1]()}
             Download for {detected[0].name}
+            {detected[0].version}
           </a>
           <p class="font-medium text-xs">Not your platform? See all options below</p>
         </div>

--- a/src/lib/components/sections/Downloads.svelte
+++ b/src/lib/components/sections/Downloads.svelte
@@ -165,7 +165,7 @@
       </p>
 
       {#if typeof detected !== 'undefined'}
-        <div id="detected-platform" class="flex flex-col items-center gap-3 mt-8">
+        <div class="flex flex-col items-center gap-3 mt-8">
           <p class="font-medium text-xs text-neutral-400 uppercase">
             Detected: {detected[0].name} ({detected[0].arch})
           </p>

--- a/src/lib/components/sections/Downloads.svelte
+++ b/src/lib/components/sections/Downloads.svelte
@@ -1,11 +1,116 @@
 <script lang="ts">
   import DualHeader from '$lib/components/common/DualHeader.svelte';
+  import { onMount } from 'svelte';
+  import type { Snippet } from 'svelte';
+
+  type Platform = {
+    name: string;
+    arch: string;
+    version: string;
+    downloadOs: string;
+    downloadArch: string;
+    downloadExt: string;
+  };
 
   const ankiVersion = '26.08.1';
 
-  function buildDownloadURL(platform: string, architecture: string, extension: string): string {
-    return `https://github.com/ankitects/anki/releases/download/${ankiVersion}/anki-${ankiVersion}-${platform}-${architecture}.${extension}`;
+  const winX64: Platform = {
+    name: 'Windows',
+    arch: 'x64',
+    version: '10+',
+    downloadOs: 'win',
+    downloadArch: 'x64',
+    downloadExt: 'msi',
+  };
+  const winArm: Platform = {
+    name: 'Windows',
+    arch: 'ARM',
+    version: '11',
+    downloadOs: 'win',
+    downloadArch: 'arm64',
+    downloadExt: 'msi',
+  };
+  const macApple: Platform = {
+    name: 'macOS',
+    arch: 'Apple Silicon',
+    version: '13+',
+    downloadOs: 'mac',
+    downloadArch: 'apple',
+    downloadExt: 'dmg',
+  };
+  const macIntel: Platform = {
+    name: 'macOS',
+    arch: 'Intel',
+    version: '13+',
+    downloadOs: 'mac',
+    downloadArch: 'intel',
+    downloadExt: 'dmg',
+  };
+  const linuxX64: Platform = {
+    name: 'Linux',
+    arch: 'x64',
+    version: '2022+',
+    downloadOs: 'linux',
+    downloadArch: 'x86_64',
+    downloadExt: 'tar.zst',
+  };
+  const linuxArm: Platform = {
+    name: 'Linux',
+    arch: 'ARM',
+    version: '2024+',
+    downloadOs: 'linux',
+    downloadArch: 'aarch64',
+    downloadExt: 'tar.zst',
+  };
+
+  function buildDownloadURL(platform: Platform): string {
+    return `https://github.com/ankitects/anki/releases/download/${ankiVersion}/anki-${ankiVersion}-${platform.downloadOs}-${platform.downloadArch}.${platform.downloadExt}`;
   }
+
+  type NavigatorUAData = {
+    getHighEntropyValues: (_hints: string[]) => Promise<{ architecture?: string }>;
+  };
+
+  async function detectPlatform(): Promise<[Platform, Snippet] | undefined> {
+    const ua = navigator.userAgent;
+
+    if (/Android|iPhone|iPad|iPod/i.test(ua)) return undefined;
+    // iPadOS Safari reports itself as macOS
+    if (/Mac/.test(ua) && navigator.maxTouchPoints > 1) return undefined;
+
+    // The UA string often hides the architecture (Chromium on Windows ARM
+    // reports x64); use Client Hints when the browser has them.
+    let arch: string | undefined;
+    const uaData = (navigator as Navigator & { userAgentData?: NavigatorUAData }).userAgentData;
+    if (uaData) {
+      try {
+        arch = (await uaData.getHighEntropyValues(['architecture'])).architecture;
+      } catch {
+        // Fall back to the UA string
+      }
+    }
+
+    if (/Windows/.test(ua)) {
+      const isArm = arch !== undefined ? arch.startsWith('arm') : /ARM64|aarch64/i.test(ua);
+      return [isArm ? winArm : winX64, windowsIcon];
+    }
+    if (/Mac/.test(ua)) {
+      // The UA string always says "Intel"; without Client Hints (Safari,
+      // Firefox), assume the more common Apple Silicon.
+      return [arch === 'x86' ? macIntel : macApple, macIcon];
+    }
+    if (/Linux|X11/.test(ua)) {
+      const isArm = arch !== undefined ? arch.startsWith('arm') : /aarch64|arm/i.test(ua);
+      return [isArm ? linuxArm : linuxX64, linuxIcon];
+    }
+    return undefined;
+  }
+
+  let detected: [Platform, Snippet] | undefined = $state();
+
+  onMount(async () => {
+    detected = await detectPlatform();
+  });
 </script>
 
 {#snippet downloadIcon()}
@@ -13,6 +118,35 @@
     <path
       fill="currentColor"
       d="M15.2446 16.4972C15.6589 16.4972 15.9946 16.833 15.9946 17.2472C15.9946 17.6269 15.7125 17.9407 15.3464 17.9904L15.2446 17.9972H4.75C4.33579 17.9972 4 17.6614 4 17.2472C4 16.8675 4.28215 16.5537 4.64823 16.5041L4.75 16.4972H15.2446ZM10.0036 1.99902C10.3833 1.99902 10.6971 2.28118 10.7468 2.64725L10.7536 2.74902L10.753 12.942L13.7192 9.97144C13.9852 9.70493 14.4019 9.68034 14.6957 9.89792L14.7799 9.97046C15.0464 10.2365 15.071 10.6531 14.8534 10.9469L14.7809 11.0311L10.538 15.2818L10.4674 15.3443L10.3764 15.4029L10.34 15.424L10.2488 15.462L10.1283 15.4921L10.0591 15.5L9.999 15.5019C9.94888 15.5019 9.89801 15.4964 9.84828 15.4859L9.76741 15.4627C9.6714 15.4317 9.58429 15.3815 9.51014 15.3167L5.22056 11.032C4.92746 10.7393 4.92712 10.2644 5.21981 9.97133C5.48588 9.70487 5.90253 9.68037 6.1963 9.89802L6.28047 9.97057L9.253 12.938L9.25362 2.74902C9.25362 2.33481 9.58941 1.99902 10.0036 1.99902Z"
+    />
+  </svg>
+{/snippet}
+
+{#snippet windowsIcon()}
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="size-6">
+    <path d="M11.4799 2H2V11.4796H11.4799V2Z" fill="currentColor" />
+    <path d="M22 2H12.5201V11.4796H22V2Z" fill="currentColor" />
+    <path d="M11.4799 12.5204H2V22H11.4799V12.5204Z" fill="currentColor" />
+    <path d="M22 12.5204H12.5201V22H22V12.5204Z" fill="currentColor" />
+  </svg>
+{/snippet}
+
+{#snippet macIcon()}
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="size-6">
+    <path
+      fill="currentColor"
+      d="M17.537 12.625a4.42 4.42 0 0 0 2.684 4.047a11 11 0 0 1-1.384 2.845c-.834 1.218-1.7 2.432-3.062 2.457c-1.34.025-1.77-.794-3.3-.794c-1.531 0-2.01.769-3.275.82c-1.316.049-2.317-1.318-3.158-2.532c-1.72-2.484-3.032-7.017-1.27-10.077A4.9 4.9 0 0 1 8.91 6.884c1.292-.025 2.51.869 3.3.869c.789 0 2.27-1.075 3.828-.917a4.67 4.67 0 0 1 3.66 1.984a4.52 4.52 0 0 0-2.16 3.805m-2.52-7.432A4.4 4.4 0 0 0 16.06 2a4.48 4.48 0 0 0-2.945 1.516a4.18 4.18 0 0 0-1.061 3.093a3.7 3.7 0 0 0 2.967-1.416Z"
+    />
+  </svg>
+{/snippet}
+
+{#snippet linuxIcon()}
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" class="size-6">
+    <path
+      fill="currentColor"
+      fill-rule="evenodd"
+      d="M113.823 104.595c-1.795-1.478-3.629-2.921-5.308-4.525c-1.87-1.785-3.045-3.944-2.789-6.678c.147-1.573-.216-2.926-2.113-3.452c.446-1.154.864-1.928 1.033-2.753c.188-.92.178-1.887.204-2.834c.264-9.96-3.334-18.691-8.663-26.835c-2.454-3.748-5.017-7.429-7.633-11.066c-4.092-5.688-5.559-12.078-5.633-18.981a47.6 47.6 0 0 0-1.081-9.475C80.527 11.956 77.291 7.233 71.422 4.7c-4.497-1.942-9.152-2.327-13.901-1.084c-6.901 1.805-11.074 6.934-10.996 14.088c.074 6.885.417 13.779.922 20.648c.288 3.893-.312 7.252-2.895 10.34c-2.484 2.969-4.706 6.172-6.858 9.397c-1.229 1.844-2.317 3.853-3.077 5.931c-2.07 5.663-3.973 11.373-7.276 16.5c-1.224 1.9-1.363 4.026-.494 6.199c.225.563.363 1.429.089 1.882c-2.354 3.907-5.011 7.345-10.066 8.095c-3.976.591-4.172 1.314-4.051 5.413c.1 3.337.061 6.705-.28 10.021c-.363 3.555.008 4.521 3.442 5.373c7.924 1.968 15.913 3.647 23.492 6.854c3.227 1.365 6.465.891 9.064-1.763c2.713-2.771 6.141-3.855 9.844-3.859c6.285-.005 12.572.298 18.86.369c1.702.02 2.679.653 3.364 2.199c.84 1.893 2.26 3.284 4.445 3.526c4.193.462 8.013-.16 11.19-3.359c3.918-3.948 8.436-7.066 13.615-9.227c1.482-.619 2.878-1.592 4.103-2.648c2.231-1.922 2.113-3.146-.135-5M62.426 24.12c.758-2.601 2.537-4.289 5.243-4.801c2.276-.43 4.203.688 5.639 3.246c1.546 2.758 2.054 5.64.734 8.658c-1.083 2.474-1.591 2.707-4.123 1.868c-.474-.157-.937-.343-1.777-.652c.708-.594 1.154-1.035 1.664-1.382c1.134-.772 1.452-1.858 1.346-3.148c-.139-1.694-1.471-3.194-2.837-3.175c-1.225.017-2.262 1.167-2.4 2.915c-.086 1.089.095 2.199.173 3.589c-3.446-1.023-4.711-3.525-3.662-7.118m-12.75-2.251c1.274-1.928 3.197-2.314 5.101-1.024c2.029 1.376 3.547 5.256 2.763 7.576c-.285.844-1.127 1.5-1.716 2.241l-.604-.374c-.23-1.253-.276-2.585-.757-3.733c-.304-.728-1.257-1.184-1.919-1.762c-.622.739-1.693 1.443-1.757 2.228c-.088 1.084.477 2.28.969 3.331c.311.661 1.001 1.145 1.713 1.916l-1.922 1.51c-3.018-2.7-3.915-8.82-1.871-11.909M87.34 86.075c-.203 2.604-.5 2.713-3.118 3.098c-1.859.272-2.359.756-2.453 2.964a102 102 0 0 0-.012 7.753c.061 1.77-.537 3.158-1.755 4.393c-6.764 6.856-14.845 10.105-24.512 8.926c-4.17-.509-6.896-3.047-9.097-6.639c.98-.363 1.705-.607 2.412-.894c3.122-1.27 3.706-3.955 1.213-6.277c-1.884-1.757-3.986-3.283-6.007-4.892c-1.954-1.555-3.934-3.078-5.891-4.629c-1.668-1.323-2.305-3.028-2.345-5.188c-.094-5.182.972-10.03 3.138-14.747c1.932-4.209 3.429-8.617 5.239-12.885c.935-2.202 1.906-4.455 3.278-6.388c1.319-1.854 2.134-3.669 1.988-5.94c-.084-1.276-.016-2.562-.016-3.843l.707-.352c1.141.985 2.302 1.949 3.423 2.959c4.045 3.646 7.892 3.813 12.319.67c1.888-1.341 3.93-2.47 5.927-3.652c.497-.294 1.092-.423 1.934-.738c2.151 5.066 4.262 10.033 6.375 15c1.072 2.524 1.932 5.167 3.264 7.547c2.671 4.775 4.092 9.813 4.07 15.272c-.012 2.83.137 5.67-.081 8.482"
+      clip-rule="evenodd"
     />
   </svg>
 {/snippet}
@@ -29,6 +163,22 @@
           installation guide
         </a>.
       </p>
+
+      {#if typeof detected !== 'undefined'}
+        <div id="detected-platform" class="flex flex-col items-center gap-3 mt-8">
+          <p class="font-medium text-xs text-neutral-400 uppercase">
+            Detected: {detected[0].name} ({detected[0].arch})
+          </p>
+          <a
+            href={buildDownloadURL(detected[0])}
+            class="flex gap-1 items-center rounded-[2rem] px-6 py-4 font-semibold tracking-tight transition-all duration-100 ease-out bg-gradient-to-r from-primary-darker to-primary text-background hover:opacity-80"
+          >
+            {@render detected[1]()}
+            Download for {detected[0].name}
+          </a>
+          <p class="font-medium text-xs">Not your platform? See all options below</p>
+        </div>
+      {/if}
     {/snippet}
   </DualHeader>
   <div>
@@ -45,84 +195,67 @@
       <div class="col-span-1 md:col-span-7 grid divide-y divide-foreground/[13%]">
         <div class="flex justify-between items-start py-3 md:px-5">
           <div class="flex items-center mt-2 gap-2">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="size-6">
-              <path d="M11.4799 2H2V11.4796H11.4799V2Z" fill="currentColor" />
-              <path d="M22 2H12.5201V11.4796H22V2Z" fill="currentColor" />
-              <path d="M11.4799 12.5204H2V22H11.4799V12.5204Z" fill="currentColor" />
-              <path d="M22 12.5204H12.5201V22H22V12.5204Z" fill="currentColor" />
-            </svg>
+            {@render windowsIcon()}
             <h4 class="font-medium text-xl">Windows</h4>
           </div>
           <div class="flex flex-col items-end gap-3">
             <a
-              href={buildDownloadURL('win', 'x64', 'msi')}
+              href={buildDownloadURL(winX64)}
               class="flex items-center gap-1 text-base font-medium text-right md:text-xl text-primary hover:opacity-60"
             >
               {@render downloadIcon()}
-              <span class="my-2">Windows 10+ (x64)</span>
+              <span class="my-2">{winX64.name} {winX64.version} ({winX64.arch})</span>
             </a>
             <a
-              href={buildDownloadURL('win', 'arm64', 'msi')}
+              href={buildDownloadURL(winArm)}
               class="flex items-center gap-1 text-base font-medium text-right md:text-xl text-primary hover:opacity-60"
             >
               {@render downloadIcon()}
-              <span class="my-2">Windows 11 (ARM)</span>
+              <span class="my-2">{winArm.name} {winArm.version} ({winArm.arch})</span>
             </a>
           </div>
         </div>
         <div class="flex justify-between items-start py-3 md:px-5">
           <div class="flex items-center mt-2 gap-2">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="size-6">
-              <path
-                fill="currentColor"
-                d="M17.537 12.625a4.42 4.42 0 0 0 2.684 4.047a11 11 0 0 1-1.384 2.845c-.834 1.218-1.7 2.432-3.062 2.457c-1.34.025-1.77-.794-3.3-.794c-1.531 0-2.01.769-3.275.82c-1.316.049-2.317-1.318-3.158-2.532c-1.72-2.484-3.032-7.017-1.27-10.077A4.9 4.9 0 0 1 8.91 6.884c1.292-.025 2.51.869 3.3.869c.789 0 2.27-1.075 3.828-.917a4.67 4.67 0 0 1 3.66 1.984a4.52 4.52 0 0 0-2.16 3.805m-2.52-7.432A4.4 4.4 0 0 0 16.06 2a4.48 4.48 0 0 0-2.945 1.516a4.18 4.18 0 0 0-1.061 3.093a3.7 3.7 0 0 0 2.967-1.416Z"
-              />
-            </svg>
+            {@render macIcon()}
             <h4 class="font-medium text-xl">macOS</h4>
           </div>
           <div class="flex flex-col items-end gap-3">
             <a
-              href={buildDownloadURL('mac', 'apple', 'dmg')}
+              href={buildDownloadURL(macApple)}
               class="flex items-center gap-1 text-base font-medium text-right md:text-xl text-primary hover:opacity-60"
             >
               {@render downloadIcon()}
-              <span class="my-2">macOS 13+ (Apple Silicon)</span>
+              <span class="my-2">{macApple.name} {macApple.version} ({macApple.arch})</span>
             </a>
             <a
-              href={buildDownloadURL('mac', 'intel', 'dmg')}
+              href={buildDownloadURL(macIntel)}
               class="flex items-center gap-1 text-base font-medium text-right md:text-xl text-primary hover:opacity-60"
             >
               {@render downloadIcon()}
-              <span class="my-2">macOS 13+ (Intel)</span>
+              <span class="my-2">{macIntel.name} {macIntel.version} ({macIntel.arch})</span>
             </a>
           </div>
         </div>
         <div class="flex justify-between items-start py-3 md:px-5">
           <div class="flex items-center mt-2 gap-2">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" class="size-6">
-              <path
-                fill="currentColor"
-                fill-rule="evenodd"
-                d="M113.823 104.595c-1.795-1.478-3.629-2.921-5.308-4.525c-1.87-1.785-3.045-3.944-2.789-6.678c.147-1.573-.216-2.926-2.113-3.452c.446-1.154.864-1.928 1.033-2.753c.188-.92.178-1.887.204-2.834c.264-9.96-3.334-18.691-8.663-26.835c-2.454-3.748-5.017-7.429-7.633-11.066c-4.092-5.688-5.559-12.078-5.633-18.981a47.6 47.6 0 0 0-1.081-9.475C80.527 11.956 77.291 7.233 71.422 4.7c-4.497-1.942-9.152-2.327-13.901-1.084c-6.901 1.805-11.074 6.934-10.996 14.088c.074 6.885.417 13.779.922 20.648c.288 3.893-.312 7.252-2.895 10.34c-2.484 2.969-4.706 6.172-6.858 9.397c-1.229 1.844-2.317 3.853-3.077 5.931c-2.07 5.663-3.973 11.373-7.276 16.5c-1.224 1.9-1.363 4.026-.494 6.199c.225.563.363 1.429.089 1.882c-2.354 3.907-5.011 7.345-10.066 8.095c-3.976.591-4.172 1.314-4.051 5.413c.1 3.337.061 6.705-.28 10.021c-.363 3.555.008 4.521 3.442 5.373c7.924 1.968 15.913 3.647 23.492 6.854c3.227 1.365 6.465.891 9.064-1.763c2.713-2.771 6.141-3.855 9.844-3.859c6.285-.005 12.572.298 18.86.369c1.702.02 2.679.653 3.364 2.199c.84 1.893 2.26 3.284 4.445 3.526c4.193.462 8.013-.16 11.19-3.359c3.918-3.948 8.436-7.066 13.615-9.227c1.482-.619 2.878-1.592 4.103-2.648c2.231-1.922 2.113-3.146-.135-5M62.426 24.12c.758-2.601 2.537-4.289 5.243-4.801c2.276-.43 4.203.688 5.639 3.246c1.546 2.758 2.054 5.64.734 8.658c-1.083 2.474-1.591 2.707-4.123 1.868c-.474-.157-.937-.343-1.777-.652c.708-.594 1.154-1.035 1.664-1.382c1.134-.772 1.452-1.858 1.346-3.148c-.139-1.694-1.471-3.194-2.837-3.175c-1.225.017-2.262 1.167-2.4 2.915c-.086 1.089.095 2.199.173 3.589c-3.446-1.023-4.711-3.525-3.662-7.118m-12.75-2.251c1.274-1.928 3.197-2.314 5.101-1.024c2.029 1.376 3.547 5.256 2.763 7.576c-.285.844-1.127 1.5-1.716 2.241l-.604-.374c-.23-1.253-.276-2.585-.757-3.733c-.304-.728-1.257-1.184-1.919-1.762c-.622.739-1.693 1.443-1.757 2.228c-.088 1.084.477 2.28.969 3.331c.311.661 1.001 1.145 1.713 1.916l-1.922 1.51c-3.018-2.7-3.915-8.82-1.871-11.909M87.34 86.075c-.203 2.604-.5 2.713-3.118 3.098c-1.859.272-2.359.756-2.453 2.964a102 102 0 0 0-.012 7.753c.061 1.77-.537 3.158-1.755 4.393c-6.764 6.856-14.845 10.105-24.512 8.926c-4.17-.509-6.896-3.047-9.097-6.639c.98-.363 1.705-.607 2.412-.894c3.122-1.27 3.706-3.955 1.213-6.277c-1.884-1.757-3.986-3.283-6.007-4.892c-1.954-1.555-3.934-3.078-5.891-4.629c-1.668-1.323-2.305-3.028-2.345-5.188c-.094-5.182.972-10.03 3.138-14.747c1.932-4.209 3.429-8.617 5.239-12.885c.935-2.202 1.906-4.455 3.278-6.388c1.319-1.854 2.134-3.669 1.988-5.94c-.084-1.276-.016-2.562-.016-3.843l.707-.352c1.141.985 2.302 1.949 3.423 2.959c4.045 3.646 7.892 3.813 12.319.67c1.888-1.341 3.93-2.47 5.927-3.652c.497-.294 1.092-.423 1.934-.738c2.151 5.066 4.262 10.033 6.375 15c1.072 2.524 1.932 5.167 3.264 7.547c2.671 4.775 4.092 9.813 4.07 15.272c-.012 2.83.137 5.67-.081 8.482"
-                clip-rule="evenodd"
-              />
-            </svg>
+            {@render linuxIcon()}
             <h4 class="font-medium text-xl">Linux</h4>
           </div>
           <div class="flex flex-col items-end gap-3">
             <a
-              href={buildDownloadURL('linux', 'x86_64', 'tar.zst')}
+              href={buildDownloadURL(linuxX64)}
               class="flex items-center gap-1 text-base font-medium text-right md:text-xl text-primary hover:opacity-60"
             >
               {@render downloadIcon()}
-              <span class="my-2">Linux (x64) 2022+</span>
+              <span class="my-2">{linuxX64.name} {linuxX64.version} ({linuxX64.arch})</span>
             </a>
             <a
-              href={buildDownloadURL('linux', 'aarch64', 'tar.zst')}
+              href={buildDownloadURL(linuxArm)}
               class="flex items-center gap-1 text-base font-medium text-right md:text-xl text-primary hover:opacity-60"
             >
               {@render downloadIcon()}
-              <span class="my-2">Linux (ARM) 2024+</span>
+              <span class="my-2">{linuxArm.name} {linuxArm.version} ({linuxArm.arch})</span>
             </a>
           </div>
         </div>


### PR DESCRIPTION
This PR implements basic platform detection and adds a download button for the detected platform.

Demo (unzip and open index.html): [anki-landing-page.zip](https://github.com/user-attachments/files/31267809/anki-landing-page.zip)


<details>

<summary>Screenshots</summary>

<img width="1344" height="232" alt="linux-arm-dark" src="https://github.com/user-attachments/assets/ee3215b6-c890-470c-8749-06bfa536f488" />
<img width="1344" height="232" alt="linux-arm-light" src="https://github.com/user-attachments/assets/48f7b7a2-9f09-4a57-a4b8-39327db49526" />
<img width="1344" height="232" alt="linux-x64-dark" src="https://github.com/user-attachments/assets/2fa4529c-7757-4ff6-b301-4f29544af3b3" />
<img width="1344" height="232" alt="linux-x64-light" src="https://github.com/user-attachments/assets/cd1a83d4-ce4c-4656-b391-1451b75c6388" />
<img width="1344" height="232" alt="mac-apple-dark" src="https://github.com/user-attachments/assets/f14bdf76-3a33-4a3f-b5d7-8fcb130cfdd6" />
<img width="1344" height="232" alt="mac-apple-light" src="https://github.com/user-attachments/assets/cbf0a9b5-4ad0-48d6-8b35-7ffc302ef57e" />
<img width="1344" height="232" alt="mac-intel-dark" src="https://github.com/user-attachments/assets/6e383d85-cb8f-4a2f-8233-2c732b488658" />
<img width="1344" height="232" alt="mac-intel-light" src="https://github.com/user-attachments/assets/ae40f3cd-fad0-456d-9810-cbb37dae8432" />
<img width="1344" height="232" alt="win-arm-dark" src="https://github.com/user-attachments/assets/6b728455-327f-4600-b5d7-164bfc30ef5e" />
<img width="1344" height="232" alt="win-arm-light" src="https://github.com/user-attachments/assets/48abf5f2-8854-40bb-badb-922568834b82" />
<img width="1344" height="232" alt="win-x64-dark" src="https://github.com/user-attachments/assets/2f3192e8-1fd2-4a77-9acc-1ae17f15929f" />
<img width="1344" height="232" alt="win-x64-light" src="https://github.com/user-attachments/assets/ce2bfcad-9916-4f0e-8781-425ed4a3c439" />


</details>

Closes #66